### PR TITLE
Add Ghostty terminal hyperlink support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## Unreleased
+
+### Added
+
+* Add hyperlink support detection for the Ghostty terminal
+  by Akshay Birajdar (@the-spectator).
+
 ## [v0.2.0] - 2024-11-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ The **TTY::Link** supports hyperlink generation in the following terminals:
 * `Contour`
 * `DomTerm`
 * `foot`
+* `Ghostty`
 * `Hyper`
 * `iTerm2`
 * `JediTerm`

--- a/lib/tty/link/errors.rb
+++ b/lib/tty/link/errors.rb
@@ -35,7 +35,7 @@ module TTY
       def initialize(class_name, method_name)
         super(format(MESSAGE, class_name: class_name, method_name: method_name))
       end
-    end
+    end # AbstractMethodError
 
     # Raised when a parameter value doesn't match the allowed values
     #

--- a/lib/tty/link/errors.rb
+++ b/lib/tty/link/errors.rb
@@ -12,6 +12,11 @@ module TTY
     #
     # @api public
     class AbstractMethodError < Error
+      # The error message template
+      #
+      # @return [String]
+      #
+      # @api private
       MESSAGE = "the %<class_name>s class must implement " \
                 "the `%<method_name>s` method"
 

--- a/lib/tty/link/errors.rb
+++ b/lib/tty/link/errors.rb
@@ -19,6 +19,7 @@ module TTY
       # @api private
       MESSAGE = "the %<class_name>s class must implement " \
                 "the `%<method_name>s` method"
+      private_constant :MESSAGE
 
       # Create an {TTY::Link::AbstractMethodError} instance
       #

--- a/lib/tty/link/terminals/ghostty.rb
+++ b/lib/tty/link/terminals/ghostty.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative "abstract"
+
+module TTY
+  class Link
+    module Terminals
+      # Responsible for detecting hyperlink support in the Ghostty terminal
+      #
+      # @api private
+      class Ghostty < Abstract
+        # The Ghostty terminal name pattern
+        #
+        # @return [Regexp]
+        #
+        # @api private
+        GHOSTTY = /ghostty/i.freeze
+        private_constant :GHOSTTY
+
+        private
+
+        # Detect Ghostty terminal
+        #
+        # @example
+        #   ghostty.name?
+        #   # => true
+        #
+        # @return [Boolean]
+        #
+        # @api private
+        def name?
+          !(term_program =~ GHOSTTY).nil?
+        end
+
+        # Detect whether the Ghostty version supports terminal hyperlinks
+        #
+        # @example
+        #   ghostty.version?
+        #   # => true
+        #
+        # @return [Boolean]
+        #
+        # @api private
+        def version?
+          return false unless term_program_version
+
+          current_semantic_version = semantic_version(term_program_version)
+
+          current_semantic_version >= semantic_version(1, 0, 0)
+        end
+      end # Ghostty
+    end # Terminals
+  end # Link
+end # TTY

--- a/spec/unit/link_spec.rb
+++ b/spec/unit/link_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe TTY::Link do
       end
     end
 
+    context "when Ghostty" do
+      it "supports links above the 1.0.0 version" do
+        env = {
+          "TERM_PROGRAM" => "ghostty",
+          "TERM_PROGRAM_VERSION" => "1.0.0"
+        }
+        link = described_class.new(env: env, output: output)
+
+        expect(link.link?).to eq(true)
+      end
+    end
+
     context "when Hyper" do
       it "supports links above the 2.0.0 version" do
         env = {

--- a/spec/unit/terminals/ghostty_spec.rb
+++ b/spec/unit/terminals/ghostty_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Link::Terminals::Ghostty, "#link?" do
+  let(:env_with_name) { {"TERM_PROGRAM" => "ghostty"} }
+  let(:semantic_version) { TTY::Link::SemanticVersion }
+
+  it "doesn't support links without the term program environment variable" do
+    ghostty = described_class.new(semantic_version, {})
+
+    expect(ghostty.link?).to eq(false)
+  end
+
+  it "doesn't support links without a terminal program name" do
+    env = {"TERM_PROGRAM" => nil}
+    ghostty = described_class.new(semantic_version, env)
+
+    expect(ghostty.link?).to eq(false)
+  end
+
+  it "doesn't support links with a non-Ghostty program name" do
+    env = {"TERM_PROGRAM" => "other-terminal"}
+    ghostty = described_class.new(semantic_version, env)
+
+    expect(ghostty.link?).to eq(false)
+  end
+
+  it "supports links above the 2.0.0 version with a mixed-case program name" do
+    env = {
+      "TERM_PROGRAM" => "GhosTTY",
+      "TERM_PROGRAM_VERSION" => "2.3.4"
+    }
+    ghostty = described_class.new(semantic_version, env)
+
+    expect(ghostty.link?).to eq(true)
+  end
+
+  it "supports links above the 1.0.0 version" do
+    env = env_with_name.merge({"TERM_PROGRAM_VERSION" => "1.0.1"})
+    ghostty = described_class.new(semantic_version, env)
+
+    expect(ghostty.link?).to eq(true)
+  end
+
+  it "supports links on the 1.0.0 version" do
+    env = env_with_name.merge({"TERM_PROGRAM_VERSION" => "1.0.0"})
+    ghostty = described_class.new(semantic_version, env)
+
+    expect(ghostty.link?).to eq(true)
+  end
+
+  it "doesn't support links below the 1.0.0 version" do
+    env = env_with_name.merge({"TERM_PROGRAM_VERSION" => "0.9.2"})
+    ghostty = described_class.new(semantic_version, env)
+
+    expect(ghostty.link?).to eq(false)
+  end
+
+  it "doesn't support links without a version" do
+    env = env_with_name.merge({"TERM_PROGRAM_VERSION" => nil})
+    ghostty = described_class.new(semantic_version, env)
+
+    expect(ghostty.link?).to eq(false)
+  end
+
+  it "doesn't support links without the term program version env variable" do
+    ghostty = described_class.new(semantic_version, env_with_name)
+
+    expect(ghostty.link?).to eq(false)
+  end
+end


### PR DESCRIPTION
Closes #2

### Describe the change

Add Ghostty terminal hyperlink support

### Why are we doing this?

To extend the supported terminal list.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
